### PR TITLE
Replaced '/' into '-' for modules with 2 codes

### DIFF
--- a/ivle-sync.py
+++ b/ivle-sync.py
@@ -27,7 +27,7 @@ class Module:
 
 class WorkbinFolder:
     def __init__(self, folderJson, path=""):
-        self.name = folderJson["FolderName"]
+        self.name = folderJson["FolderName"].replace('/', '-')
         self.id = folderJson["ID"]
         self.path = join(path, self.name)
 


### PR DESCRIPTION
Some modules have 2 codes, such as UTC1102H/GEM1902H, which results in the directory structure ./UTC1102H/GEM1902H/ which is the expected behaviour.

So instead, I follow IVLEDownloader's behaviour of replacing slash occurences with a dash.