### PR TITLE
Bugfix: replace should be on module not folder

### DIFF
--- a/ivle-sync.py
+++ b/ivle-sync.py
@@ -21,13 +21,13 @@ USER_AGENT = "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko
 class Module:
     def __init__(self, moduleId, name, code):
         self.id = moduleId
-        self.name = name
+        self.name = name.replace('/', '-')
         self.code = code
 
 
 class WorkbinFolder:
     def __init__(self, folderJson, path=""):
-        self.name = folderJson["FolderName"].replace('/', '-')
+        self.name = folderJson["FolderName"]
         self.id = folderJson["ID"]
         self.path = join(path, self.name)
 


### PR DESCRIPTION
My apologies! My bad I didn't test this thoroughly. The replace should be on the module not on the folder, as said on the title.