### PR TITLE
Fetch webcasts from Panopto

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ name = "pypi"
 
 requests = "*"
 "bs4" = "*"
+tqdm = "*"
 
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "95ad77fb0b9413a00efff89ea316743d70bae3dd2892897cbd5ba6a382c3e3b5"
+            "sha256": "1cc2825fc733361b20239dc8923cb1812e88c717706213d4807bff0d5619488b"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
@@ -43,10 +43,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:244be0d93b71e93fc0a0a479862051414d0e00e16435707e5bf5000f92e04694",
-                "sha256:5ec74291ca1136b40f0379e1128ff80e866597e4e2c1e755739a913bbc3613c0"
+                "sha256:14131608ad2fd56836d33a71ee60fa1c82bc9d2c8d98b7bdbc631fe1b3cd1296",
+                "sha256:edbc3f203427eef571f79a7692bb160a2b0f7ccaa31953e99bd17e307cf63f7d"
             ],
-            "version": "==2017.11.5"
+            "version": "==2018.1.18"
         },
         "chardet": {
             "hashes": [
@@ -68,6 +68,13 @@
                 "sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"
             ],
             "version": "==2.18.4"
+        },
+        "tqdm": {
+            "hashes": [
+                "sha256:4c041f8019f7be65b8028ddde9a836f7ccc51c4637f1ff2ba9b5813d38d19d5a",
+                "sha256:df32e6f127dc0ccbc675eadb33f749abbcb8f174c5cb9ec49c0cdb73aa737377"
+            ],
+            "version": "==4.19.5"
         },
         "urllib3": {
             "hashes": [

--- a/ivle-sync.py
+++ b/ivle-sync.py
@@ -4,6 +4,7 @@ from getpass import getpass
 from os import makedirs, remove
 from sys import argv, exit
 from os.path import join, dirname, isfile, realpath
+from tqdm import tqdm
 import re
 import requests
 import json
@@ -169,15 +170,36 @@ class IVLESession:
         print("Downloading " + webcast.title + ".")
         r = self.s.get(webcast.url, stream=True, cookies=cookies)
 
-        if isfile(webcast.title):
+        title = webcast.title + ".mp4"
+
+        if isfile(title):
             return
 
+        done = False
         try:
-            with open(webcast.title, 'wb') as f:
-                for chunk in r.iter_content(1024):
+            total = int(r.headers.get('Content-Length', 0)) // (1024)
+            with open(title, 'wb') as f:
+                for chunk in tqdm(
+                        r.iter_content(1024),
+                        total=total,
+                        miniters=1,
+                        bar_format="{desc}{"
+                        "percentage:3.0f}%"
+                        " {rate_fmt}"
+                        " Elapsed: {"
+                        "elapsed}"
+                        " Remaining: {"
+                        "remaining}",
+                        unit='kB',
+                        unit_divisor=1024,
+                        unit_scale=True):
                     f.write(chunk)
-        except:
-            os.remove(webcast.title)
+            done = True
+        except Exception:
+            pass
+        finally:
+            if not done:
+                remove(title)
 
     def download_file(self, file):
         params = {
@@ -198,12 +220,31 @@ class IVLESession:
             stream=True,
             params=params)
 
+        done = False
         try:
+            total = int(r.headers.get('Content-Length', 0)) // (1024)
             with open(file.path, 'wb') as f:
-                for chunk in r.iter_content(1024):
+                for chunk in tqdm(
+                        r.iter_content(1024),
+                        total=total,
+                        miniters=1,
+                        bar_format="{desc}{"
+                        "percentage:3.0f}%"
+                        " {rate_fmt}"
+                        " Elapsed: {"
+                        "elapsed}"
+                        " Remaining: {"
+                        "remaining}",
+                        unit='kB',
+                        unit_divisor=1024,
+                        unit_scale=True):
                     f.write(chunk)
-        except:
-            remove(file.path)
+            done = True
+        except Exception:
+            pass
+        finally:
+            if not done:
+                remove(file.path)
 
     def download_folder(self, target_folder):
         for folder in target_folder.folders:

--- a/ivle-sync.py
+++ b/ivle-sync.py
@@ -201,7 +201,6 @@ class IVLESession:
             '.ASPXAUTH': self.panopto_token
         }
 
-        print("Downloading " + webcast.module.code + "/" + webcast.title + ".mp4")
         r = self.s.get(webcast.url, stream=True, cookies=cookies)
 
         path = join(webcast.module.code, "Webcasts", webcast.title + ".mp4")
@@ -210,6 +209,8 @@ class IVLESession:
 
         if isfile(path):
             return
+
+        print("Downloading " + webcast.module.code + "/" + webcast.title + ".mp4")
 
         done = False
         try:
@@ -226,9 +227,7 @@ class IVLESession:
                         "elapsed}"
                         " Remaining: {"
                         "remaining}",
-                        unit='kB',
-                        unit_divisor=1024,
-                        unit_scale=True):
+                        unit='kB'):
                     f.write(chunk)
             done = True
         except Exception:
@@ -310,9 +309,12 @@ def sync_webcasts(session):
     modules = session.get_modules()
 
     for module in modules:
+        print("=== " + module.code + ": " + module.name + " ===")
+
         webcasts = session.get_webcasts(module)
         for webcast in webcasts:
             session.download_webcast(webcast)
+        print()
 
 
 def get_credentials():

--- a/ivle-sync.py
+++ b/ivle-sync.py
@@ -256,31 +256,12 @@ class IVLESession:
             stream=True,
             params=params)
 
-        done = False
         try:
-            total = int(r.headers.get('Content-Length', 0)) // (1024)
             with open(file.path, 'wb') as f:
-                for chunk in tqdm(
-                        r.iter_content(1024),
-                        total=total,
-                        miniters=1,
-                        bar_format="{desc}{"
-                        "percentage:3.0f}%"
-                        " {rate_fmt}"
-                        " Elapsed: {"
-                        "elapsed}"
-                        " Remaining: {"
-                        "remaining}",
-                        unit='kB',
-                        unit_divisor=1024,
-                        unit_scale=True):
+                for chunk in r.iter_content(1024):
                     f.write(chunk)
-            done = True
-        except Exception:
-            pass
-        finally:
-            if not done:
-                remove(file.path)
+        except:
+            remove(file.path)
 
     def download_folder(self, target_folder):
         for folder in target_folder.folders:

--- a/ivle-sync.py
+++ b/ivle-sync.py
@@ -165,20 +165,27 @@ class IVLESession:
             params=params).json()
 
     def download_webcast(self, webcast):
-        cookies = {'.ASPXAUTH': 'a 480 characters long hash'}
+        # This link redirects to IVLE, prompting for login
+        # "https://fac.weblecture.nus.edu.sg/Panopto/Pages/Auth/Login.aspx?ReturnUrl=https%3A%2F%2Ffac.weblecture.nus.edu.sg%2FPanopto%2FPages%2FHome.aspx&instance=nus&AllowBounce=true"
 
-        print("Downloading " + webcast.title + ".")
+        cookies = {
+            '.ASPXAUTH': ''
+        }
+
+        print("Downloading " + webcast.module.code + "/" + webcast.title + ".")
         r = self.s.get(webcast.url, stream=True, cookies=cookies)
 
-        title = webcast.title + ".mp4"
+        path = join(webcast.module.code, "Webcasts", webcast.title + ".mp4")
 
-        if isfile(title):
+        makedirs(dirname(path), exist_ok=True)
+
+        if isfile(path):
             return
 
         done = False
         try:
             total = int(r.headers.get('Content-Length', 0)) // (1024)
-            with open(title, 'wb') as f:
+            with open(path, 'wb') as f:
                 for chunk in tqdm(
                         r.iter_content(1024),
                         total=total,


### PR DESCRIPTION
This PR should complete the webcast feature.

[tqdm](https://github.com/tqdm/tqdm) is added as a dependency to provide a progress bar for webcast downloads (as they are usually ~500MB)

There should be a way to skip downloading webcasts, as they are huge (I can't keep a whole semester worth of webcasts on my laptop's SSD)

Closes #1